### PR TITLE
Check and fix chatbox scrolling bug

### DIFF
--- a/components/ai-chat.tsx
+++ b/components/ai-chat.tsx
@@ -25,13 +25,26 @@ export function AIChat() {
   const [input, setInput] = useState("")
   const [isLoading, setIsLoading] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
+  const previousMessageCount = useRef(messages.length)
 
   const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+    // Use a more gentle scroll approach
+    messagesEndRef.current?.scrollIntoView({ 
+      behavior: "smooth", 
+      block: "end",
+      inline: "nearest"
+    })
   }
 
   useEffect(() => {
-    scrollToBottom()
+    // Only scroll to bottom if new messages were actually added
+    if (messages.length > previousMessageCount.current) {
+      // Add a small delay to ensure DOM is updated
+      setTimeout(() => {
+        scrollToBottom()
+      }, 50)
+      previousMessageCount.current = messages.length
+    }
   }, [messages])
 
   const sendMessage = async (e: React.FormEvent) => {
@@ -153,7 +166,8 @@ export function AIChat() {
             onChange={(e) => setInput(e.target.value)}
             placeholder="Ask me anything about school..."
             disabled={isLoading}
-            className="flex-1"
+            className="flex-1 focus:scroll-m-0"
+            style={{ scrollMargin: 0 }}
           />
           <Button type="submit" size="sm" disabled={!input.trim() || isLoading}>
             <Send className="h-4 w-4" />


### PR DESCRIPTION
Fix unwanted scrolling when clicking the chatbox input by refining scroll logic and input focus behavior.

Previously, clicking the chatbox input could trigger a re-render that caused the `useEffect` hook to call `scrollToBottom()`, leading to an unexpected scroll. This PR ensures scrolling only occurs when new messages are genuinely added and prevents input focus from causing scroll events.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5563eb7-799f-4bc3-a122-f53a523e1db0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5563eb7-799f-4bc3-a122-f53a523e1db0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

